### PR TITLE
Fix: Fixed an Unhandled Exception

### DIFF
--- a/exercise3/start/Astronomy/Astronomy/Data/LatLongService.cs
+++ b/exercise3/start/Astronomy/Astronomy/Data/LatLongService.cs
@@ -11,9 +11,16 @@
             if (status == PermissionStatus.Granted)
             {
                 var request = new GeolocationRequest(GeolocationAccuracy.Default, TimeSpan.FromSeconds(10));
-                var location = await Geolocation.GetLocationAsync(request);
-                latLoc = location.Latitude;
-                longLoc = location.Longitude;
+                try
+                {
+                    var location = await Geolocation.GetLocationAsync(request);
+                    latLoc = location.Latitude;
+                    longLoc = location.Longitude;
+                } catch (FeatureNotEnabledException)
+                {
+                    // TODO: Implement a way to inform user for enabling the location service in their device's settings
+                }
+
             }
             return (latLoc, longLoc);
         }


### PR DESCRIPTION
This fixes (FeatureNotEnabledException) when location permission is granted but the location feature is disabled in device settings.
Tested on Android 10.0 - API 29

This fix only prevents application crash, but does not inform user of the error. implementing this function is currently beyond my knowledge.